### PR TITLE
RFC6455 conformance for AS3WebSocket. 

### DIFF
--- a/AS3WebSocket/src/com/worlize/websocket/WebSocketCloseStatus.as
+++ b/AS3WebSocket/src/com/worlize/websocket/WebSocketCloseStatus.as
@@ -2,11 +2,19 @@ package com.worlize.websocket
 {
 	public final class WebSocketCloseStatus
 	{
-		// http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-06#section-7.4
+		// http://tools.ietf.org/html/rfc6455#section-7.4
 		public static const NORMAL:int = 1000;
 		public static const GOING_AWAY:int = 1001;
 		public static const PROTOCOL_ERROR:int = 1002;
 		public static const UNPROCESSABLE_INPUT:int = 1003;
-		public static const MESSAGE_TOO_LARGE:int = 1004;
+		public static const UNDEFINED:int = 1004;
+		public static const NO_CODE:int = 1005;
+		public static const NO_CLOSE:int = 1006;
+		public static const BAD_PAYLOAD:int = 1007;
+		public static const POLICY_VIOLATION:int = 1008;
+		public static const MESSAGE_TOO_LARGE:int = 1009;
+		public static const REQUIRED_EXTENSION:int = 1010;
+		public static const SERVER_ERROR:int = 1011;
+		public static const FAILED_TLS_HANDSHAKE:int = 1015;
 	}
 }

--- a/AS3WebSocket/src/com/worlize/websocket/WebSocketConfig.as
+++ b/AS3WebSocket/src/com/worlize/websocket/WebSocketConfig.as
@@ -30,5 +30,6 @@ package com.worlize.websocket
 		// for an acknowledgement to come back before giving up and just
 		// closing the socket.
 		public var closeTimeout:uint = 5000;
+		
 	}
 }

--- a/AS3WebSocket/src/com/worlize/websocket/WebSocketOpcode.as
+++ b/AS3WebSocket/src/com/worlize/websocket/WebSocketOpcode.as
@@ -6,12 +6,14 @@ package com.worlize.websocket
 		public static const CONTINUATION:int = 0x00;
 		public static const TEXT_FRAME:int = 0x01;
 		public static const BINARY_FRAME:int = 0x02;
-		// 0x03 - 0x07 = Reserved for further control frames
+		public static const EXT_DATA:int = 0x03;
+		// 0x04 - 0x07 = Reserved for further control frames
 		
 		// Control opcodes 
 		public static const CONNECTION_CLOSE:int = 0x08;
 		public static const PING:int = 0x09;
 		public static const PONG:int = 0x0A;
-		// 0x0B - 0x0F = Reserved for further control frames
+		public static const EXT_CONTROL:int = 0x0B;
+		// 0x0C - 0x0F = Reserved for further control frames
 	}
 }

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ActionScript 3 WebSocket Client
 ===============================
 
-*This is an AS3 implementation of a client library of the WebSocket protocol, as specified in the -10 draft.*
+*This is an AS3 implementation of a client library of the WebSocket protocol, as specified in the rfc6455 standard.*
 
 Explanation
 -----------
-THIS CLIENT WILL NOT WORK with draft-75 or draft-76/-00 servers that are deployed on the internet.  It is only for the most recent -10 draft.  Once the next draft is released I will update this client to work only with that version, and so on, until the final version of the protocol is ratified by the IETF.  I will keep a version tracking each of the IETF drafts in its own branch, with master tracking the latest.
+THIS CLIENT WILL NOT WORK with draft-75 or draft-76/-00 servers that are deployed on the internet.  It is only for the most recent rfc6455 standard. I will keep a version tracking each of the IETF drafts in its own branch, with master tracking the latest.
 
 I intend to keep this library updated to the latest draft of the IETF WebSocket protocol when new versions are released.  I built this library because I wanted to be able to make use of the latest draft of the protocol, but no browser implements it yet.
 
@@ -24,7 +24,7 @@ Download
 
 Features
 --------
-- Based on -10 draft of the WebSocket protocol
+- Based on the rfc6455 standard WebSocket protocol
 - wss:// TLS support w/ hurlant as3crypto library
   - Learn more here: [as3crypto on Google Code](http://code.google.com/p/as3crypto/)
 - Can send and receive fragmented messages


### PR DESCRIPTION
I combed through the docs and it does indeed seem that the only practical wire changes between protocol 8 and 13 are the renamed Origin header and a few of the closure status codes. I updated those, but then couldn't help myself and also added multiple subprotocol support as described in the doc. I also optimized the frame masking algorithm to improve throughput by about 2.8x.  I also added a "psedo masking" mode that is useful in particular situations in which the client is embedded and not in danger of being hijacked by a rogue javascript snipped. In this mode, the mask key is always 0, enabling the client to skip the costly masking step completely. Obviously only useful in situations where you're not worried about arbitrary data going across the wire.

I've tested the changes against Jetty 8.1.2, which implements RFC6455 on the server side, everything seems good. I haven't tested through all the error conditions or given it thorough real-world testing.

If there's more here than you want to digest at once, let me know, I can probably break out some of it. Also, I'm new to github so my apologies if it would have been easier for you if I had made a new branch for this. I guess in the worst case I can just go use my own fork from here on out. The magic of github!
