### PR TITLE
Use hurlant SHA1 instead of adobe, since the latter uses flex libraries.

### DIFF
--- a/AS3WebSocket/src/com/worlize/websocket/WebSocket.as
+++ b/AS3WebSocket/src/com/worlize/websocket/WebSocket.as
@@ -16,15 +16,16 @@
 
 package com.worlize.websocket
 {
-	import com.adobe.crypto.SHA1;
 	import com.adobe.net.URI;
 	import com.adobe.net.URIEncodingBitmap;
 	import com.adobe.utils.StringUtil;
+	import com.hurlant.crypto.hash.SHA1;
 	import com.hurlant.crypto.tls.TLSConfig;
 	import com.hurlant.crypto.tls.TLSEngine;
 	import com.hurlant.crypto.tls.TLSSecurityParameters;
 	import com.hurlant.crypto.tls.TLSSocket;
 	import com.hurlant.util.Base64;
+	import com.hurlant.util.Hex;
 	
 	import flash.events.Event;
 	import flash.events.EventDispatcher;
@@ -847,7 +848,9 @@ package com.worlize.websocket
 						serverExtensions = serverExtensions.concat(extensionsThisLine);
 					}
 					else if (lcName === 'sec-websocket-accept') {
-						var expectedKey:String = SHA1.hashToBase64(base64nonce + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+						var byteArray:ByteArray = new ByteArray();
+						byteArray.writeUTFBytes(base64nonce + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+						var expectedKey:String = Base64.encodeByteArray(new SHA1().hash(byteArray));
 						if (debug) {
 							logger("Expected Sec-WebSocket-Accept value: " + expectedKey);
 						}


### PR DESCRIPTION
When running this code in pure Flash, a runtime failure occurs because com.adobe.crypto.SHA1 uses some library that's only available in Flex. Since the project already includes hurlant, which has a SHA1, I use that instead.
Thanks to elct9620 for his idea in https://github.com/Worlize/AS3WebSocket/issues/15
