### PR TITLE
Added a tiny bit of debugging to failHandshake to indicate what failed.

### DIFF
--- a/AS3WebSocket/src/com/worlize/websocket/WebSocket.as
+++ b/AS3WebSocket/src/com/worlize/websocket/WebSocket.as
@@ -715,6 +715,9 @@ package com.worlize.websocket
 		}
 		
 		private function failHandshake(message:String = "Unable to complete websocket handshake."):void {
+			if (debug) {
+				logger(message);
+			}
 			_readyState = WebSocketState.CLOSED;
 			if (socket.connected) {
 				socket.close();


### PR DESCRIPTION
This tiny bit of debugging info was very helpful in tracking down problems, so thought I'd add it. When the handshake fails, and debugging is enabled, it will now output the problem directly.
